### PR TITLE
Added a more updated alternative to isomorphic-fetch.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 require('es6-promise').polyfill()
-var fetch = require('isomorphic-fetch')
+var fetch = require('cross-fetch')
 var meow = require('meow')
 var fs = require('fs')
 var getStdin = require('get-stdin')

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "graphql"
   ],
   "dependencies": {
+    "cross-fetch": "~1.1.0",
     "es6-promise": "~3.1.2",
     "get-stdin": "^5.0.1",
     "graphql": "^0.9.1",
-    "isomorphic-fetch": "~2.2.1",
     "lodash": "^4.6.1",
     "meow": "^3.7.0"
   },


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.