### PR TITLE
Auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Examples
   $ graphqlviz schema.json --theme.header.invert=true | dot -Tpng > schema.png
 ```
 
+Note that `dot` is `graphviz`'s tool to produce layered drawings of directed graphs. `graphviz` is available through most package managers including homebrew and apt-get. Details here https://www.graphviz.org/download/
+
 ## Customizing output
 
 You can print default theme with `graphqlviz --print-theme > theme.json`, then you can modify it, and pass with `--theme theme.json` argument. All the available colors can be found on the [graphviz site](http://www.graphviz.org/doc/info/colors.html). 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Examples
   $ graphqlviz schema.json --theme.header.invert=true | dot -Tpng > schema.png
 ```
 
-Note that `dot` is `graphviz`'s tool to produce layered drawings of directed graphs. `graphviz` is available through most package managers including homebrew and apt-get. Details here https://www.graphviz.org/download/
+Note that `dot` is `graphviz`'s tool to produce layered drawings of directed graphs. `graphviz` is available through most package managers including homebrew and apt-get. Details here: https://www.graphviz.org/download/
 
 ## Customizing output
 

--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,7 @@ var cli = meow(`
       -t --theme      path to theme overrides
       --print-theme   print default theme to stdout
       -v --verbose    print introspection result
+      -a --auth       set Authorization header for graphql server
 
     Usage:
       $ graphqlviz [url]
@@ -24,6 +25,7 @@ var cli = meow(`
 
     Examples:
       $ graphqlviz https://localhost:3000 | dot -Tpng -o graph.png
+      $ graphqlviz https://www.mypublicautheddomain.com/graphql -a "Bearer xxxxx" | dot -Tpng -o graph.png
       $ graphqlviz https://swapi.apis.guru | dot -Tpng | open -f -a Preview
       $ graphqlviz path/to/schema.json | dot -Tpng | open -f -a Preview
       $ graphqlviz path/to/schema.graphql -g | dot -Tpng | open -f -a Preview
@@ -43,6 +45,10 @@ var cli = meow(`
     graphql: {
       type: 'boolean',
       alias: 'g'
+    },
+    auth: {
+      type: 'string',
+      alias: 'a'
     }
   }
 })
@@ -110,12 +116,16 @@ if (cli.input[0] === 'query') {
 
   // otherwise http(s)
   if (cli.input[0].slice(0, 4) === 'http') {
+    var headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    };
+    if (cli.flags.auth) {
+      headers.Authorization = cli.flags.auth;
+    }
     p = fetch(cli.input[0], {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
+      headers: headers,
       body: JSON.stringify({query: graphqlviz.query})
     }).then(function (res) {
       return res.text()

--- a/cli.js
+++ b/cli.js
@@ -128,8 +128,11 @@ if (cli.input[0] === 'query') {
       headers: headers,
       body: JSON.stringify({query: graphqlviz.query})
     }).then(function (res) {
-      return res.text()
-    })
+      if (!res.ok && cli.flags.verbose) {
+        console.log('Request for schema failed w/ ' + res.status + ' (' + res.statusText + ')');
+      }
+      return res.text();
+    });
   } else {
     // if not http, try local file
     p = new Promise(function (resolve, reject) {


### PR DESCRIPTION
Addresses https://github.com/sheerun/graphqlviz/issues/16

usage:
```
node cli.js -a mytoken https://mywebsite.com/graphql
```

example of error:
```
➜  graphqlviz git:(auth-header) node cli.js -a incorrectToken -v https://mywebsite.com/graphql
Request for schema failed w/ 406 (Not Acceptable)

  GraphQL Server CLI visualizer

  Options:
    -g --graphql    use graphql schema language as input
    -t --theme      path to theme overrides
    --print-theme   print default theme to stdout
    -v --verbose    print introspection result
    -a --auth       set Authorization header for graphql server

  Usage:
    $ graphqlviz [url]
        Renders dot schema from [url] endpoint

  Examples:
    $ graphqlviz https://localhost:3000 | dot -Tpng -o graph.png
    $ graphqlviz https://www.mypublicautheddomain.com/graphql -a "Bearer xxxxx" | dot -Tpng -o graph.png
    $ graphqlviz https://swapi.apis.guru | dot -Tpng | open -f -a Preview
    $ graphqlviz path/to/schema.json | dot -Tpng | open -f -a Preview
    $ graphqlviz path/to/schema.graphql -g | dot -Tpng | open -f -a Preview
    $ graphqlviz --print-theme > theme.json
    $ graphqlviz https://localhost:3000 -t theme.json | dot -Tpng | open -f -a Preview
    $ graphqlviz schema.json --theme.header.invert=true | dot -Tpng > schema.png

```

Also added a note to README because I did not initally know what `dot` was, and I suspect I may not be alone.