### PR TITLE
Improved error msg when run without TTY

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -108,6 +108,7 @@ if (cli.input[0] === 'query') {
     // stdin
     p = getStdin().then(function (stdin) {
       if (stdin.trim() === '') {
+        console.error('ERROR: When run without a TTY; data must be provided in stdin')
         return terminate()
       }
       return stdin


### PR DESCRIPTION
Took us a lot of time to figure out why things didn't work in our bitbucket pipeline. This simple error msg would at least explain why it failed.

 Should considder supporting arguments without a TTY as well.